### PR TITLE
changed the magic numbers eslint rule to allow 0,1,2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -51,7 +51,7 @@
     "no-extra-semi": 1,
     "no-unreachable": 1,
     "no-unused-expressions": 1,
-    "no-magic-numbers": 1,
+    "no-magic-numbers": ["error", { "ignore": [0, 1, 2] }],
     "react/prefer-es6-class": 1
   }
 }

--- a/src/components/Tester/Tester.js
+++ b/src/components/Tester/Tester.js
@@ -2,9 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Timeline, TimelineItem } from '..';
 
-const ZERO = 0;
-const ONE = 1;
-
 /**
  * The tester is a temporary component that provides buttons
  * to step forwards/backwards through the steps.
@@ -17,10 +14,10 @@ export class Tester extends React.Component {
   }
 
   handlePrevious = () =>
-    this.setState({ step: this.state.step === ZERO ? ZERO : this.state.step - ONE });
+    this.setState({ step: this.state.step === 0 ? 0 : this.state.step - 1 });
 
   handleNext = () =>
-    this.setState({ step: this.state.step + ONE });
+    this.setState({ step: this.state.step + 1 });
 
   render () {
 

--- a/src/components/Timeline/__tests__/Timeline.spec.js
+++ b/src/components/Timeline/__tests__/Timeline.spec.js
@@ -11,8 +11,7 @@ describe('<Timeline />', () => {
         <TimelineItem key={1} header="Header 1">Body 1</TimelineItem>
       ]} />
     );
-    const EXPECTED = 2;
-    expect(wrapper.find('TimelineItem').length).toEqual(EXPECTED);
+    expect(wrapper.find('TimelineItem').length).toEqual(2);
   });
 
   it ('should render the first body', () => {
@@ -22,8 +21,7 @@ describe('<Timeline />', () => {
         <TimelineItem key={1} header="Header 1">Body 1</TimelineItem>
       ]} />
     );
-    const ONE = 1;
-    expect(wrapper.findWhere(x => x.text() === 'Body 0').length).toEqual(ONE);
+    expect(wrapper.findWhere(x => x.text() === 'Body 0').length).toEqual(1);
   });
 
 });


### PR DESCRIPTION
 These numbers are pretty commonly required, if this becomes a problem we can re-enable this rule. updated any unnecessary `consts` defined.